### PR TITLE
Preserve HTTP credentials when enabling long polling

### DIFF
--- a/bitcoin.rb
+++ b/bitcoin.rb
@@ -112,7 +112,12 @@ module Bitcoin
       raise JSONRPCError.new(json['error']) if json['error']
 
       if block_given? and poll_path = response['X-Long-Polling']
-        yield self.class.new(@uri + poll_path, @user_agent, LONG_POLL_TIMEOUT)
+        poll_uri = URI.parse(poll_path)
+        if @uri.user
+          poll_uri.user = @uri.user
+          poll_uri.password = @uri.password
+        end
+        yield self.class.new(poll_uri, @user_agent, LONG_POLL_TIMEOUT)
       end
 
       json['result']

--- a/bitcoin.rb
+++ b/bitcoin.rb
@@ -113,6 +113,7 @@ module Bitcoin
 
       if block_given? and poll_path = response['X-Long-Polling']
         poll_uri = URI.parse(poll_path)
+        poll_uri = @uri.merge(poll_uri) if poll_uri.kind_of?(URI::Generic)
         if @uri.user
           poll_uri.user = @uri.user
           poll_uri.password = @uri.password


### PR DESCRIPTION
The header field X-Long-Polling can contain a complete URL or a path.[0] cellminer fails to use the credentials if a complete URL is used, but this patch should fix it.

[0] http://deepbit.net/longpolling.php
