### PR TITLE
Reduce timeouts and queue sizes to improve reaction times to pool changes

### DIFF
--- a/bitcoin.rb
+++ b/bitcoin.rb
@@ -52,7 +52,7 @@ module Bitcoin
   end
 
   class RPCProxy
-    LONG_POLL_TIMEOUT = 60 * 60 * 12
+    LONG_POLL_TIMEOUT = 60 * 5
 
     class JSONRPCError < StandardError
       attr_reader :code


### PR DESCRIPTION
My blades sometimes have network trouble, so I reduced the timeouts. I also dynamically calculate the queue size based on the number of used SPEs.
