### PR TITLE
Fix issue #9

### DIFF
--- a/bitcoin.rb
+++ b/bitcoin.rb
@@ -45,6 +45,9 @@ module Bitcoin
     # This is a workaround; URI needs escaped username and password
     if username
       uri.user     = URI.escape username, /[^#{URI::PATTERN::UNRESERVED}]/
+      uri.password = '-1'
+    end
+    if password
       uri.password = URI.escape password, /[^#{URI::PATTERN::UNRESERVED}]/
     end
 


### PR DESCRIPTION
Eligius does not require a password, so make it default to the same value that bfgminer uses: -1 (Eligius ignores this anyway)
